### PR TITLE
Fix Twitter reply parameter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -185,7 +185,7 @@ class BitcoinMiningNewsBot:
                 # Post as a reply to create a thread
                 second_tweet = self.twitter_client.create_tweet(
                     text=f"Read more: {article_url}",
-                    in_reply_to_tweet_id=first_tweet_id
+                    reply={"in_reply_to_tweet_id": first_tweet_id}
                 )
                 logger.info(f"Posted second tweet (reply) with link to article")
             


### PR DESCRIPTION
## Summary
- update the reply tweet call to use the supported reply parameter when threading tweets

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68cb56d9466c83298c1cc5d6d653497e