### PR TITLE
Grant workflow token push permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:  # Allows manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   tweet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- configure the workflow token with write access to repository contents so scheduled runs can push updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb574033108329aac4e7e69b6ac4ef