### PR TITLE
Fix logger initialization and handle missing PIL

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,14 @@ from datetime import datetime, timedelta
 
 import tweepy
 
+# Configure logging before any modules attempt to use the shared logger
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger('bitcoin_mining_bot')
+
 try:
     from tweepy.errors import TooManyRequests as TweepyTooManyRequests  # type: ignore
 except (ImportError, AttributeError):
@@ -24,10 +32,10 @@ except (ImportError, AttributeError):
             # Extract known attributes before calling super()
             response = kwargs.pop('response', None)
             api_errors = kwargs.pop('api_errors', None)
-            
+
             # Call super with only positional args (avoid kwargs issue)
             super().__init__(*args)
-            
+
             # Store additional attributes for compatibility
             self.response = response
             self.api_errors = api_errors
@@ -49,14 +57,6 @@ except ImportError as e:
     logger.warning(f"Image support not available: {e}")
     ImageSelector = None
     IMAGE_SUPPORT_AVAILABLE = False
-
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
-logger = logging.getLogger('bitcoin_mining_bot')
 
 
 class BitcoinMiningNewsBot:

--- a/image_library.py
+++ b/image_library.py
@@ -10,8 +10,14 @@ import logging
 import requests
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
-from PIL import Image
 import io
+
+try:
+    from PIL import Image  # type: ignore
+    PIL_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised indirectly via bot
+    Image = None  # type: ignore
+    PIL_AVAILABLE = False
 
 logger = logging.getLogger('image_library')
 
@@ -144,6 +150,10 @@ class ImageLibrary:
     
     def download_image(self, url: str, filename: str) -> Optional[str]:
         """Download an image from URL and save locally"""
+        if not PIL_AVAILABLE:
+            logger.warning("Pillow not available - skipping image download")
+            return None
+
         try:
             headers = {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'


### PR DESCRIPTION
## Summary
- initialize the shared logger before optional image imports to avoid NameError when Pillow is missing
- allow the image library to operate without Pillow by guarding the import and skipping downloads when unavailable

## Testing
- pytest test_image_functionality.py -q
- pytest test_image_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cdc430fd988329805fda31d5d19b6d