### PR TITLE
Add Gemini article generation workflow and tests

### DIFF
--- a/gemini_client.py
+++ b/gemini_client.py
@@ -1,11 +1,12 @@
-"""
-Gemini AI client for Bitcoin Mining News Bot
-"""
+"""Gemini AI client utilities for the Bitcoin Mining News Bot."""
 
+from __future__ import annotations
+
+import json
 import logging
 import os
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 from google import genai
 from google.genai import types
@@ -15,70 +16,121 @@ from config import GeminiConfig
 logger = logging.getLogger('bitcoin_mining_bot')
 
 
+def create_filename_slug(title: str) -> str:
+    """Create a filesystem-safe slug derived from a title string."""
+    import re
+
+    slug = re.sub(r'[^\w\s-]', '', (title or '').lower())
+    slug = re.sub(r'[-\s]+', '_', slug)
+    return slug[:50]
+
+
 class GeminiClient:
-    """Wrapper for Google Gemini AI client using the new google-genai SDK"""
-    
+    """Wrapper for Google Gemini AI client using the google-genai SDK."""
+
     def __init__(self, config: GeminiConfig):
-        """Initialize Gemini client"""
+        """Initialize Gemini client."""
         # The new SDK automatically picks up GEMINI_API_KEY from environment
-        # No need to manually configure the API key
         self.client = genai.Client()
         logger.info("Gemini AI client initialized successfully with new SDK")
-    
+
     def analyze_article(self, article: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Analyze a news article using Gemini AI
-        
-        Args:
-            article: Article dictionary containing title, body, url, etc.
-            
-        Returns:
-            Dictionary containing analysis results
-        """
+        """Analyze a news article using Gemini AI."""
         try:
-            # Extract article information
             title = article.get('title', 'No title')
             body = article.get('body', article.get('summary', 'No content'))
             url = article.get('url', article.get('uri', 'No URL'))
-            
-            # Create analysis prompt
+
             prompt = self._create_analysis_prompt(title, body, url)
-            
-            # Generate analysis using new API
+
             logger.info(f"Analyzing article: {title[:50]}...")
             response = self.client.models.generate_content(
                 model="gemini-2.5-flash",
                 contents=prompt,
                 config=types.GenerateContentConfig(
-                    thinking_config=types.ThinkingConfig(thinking_budget=0)  # Disable thinking for speed
-                )
+                    thinking_config=types.ThinkingConfig(thinking_budget=0)
+                ),
             )
-            
-            # Return structured analysis
+
             analysis = {
                 'article_title': title,
                 'article_url': url,
                 'analysis_text': response.text,
                 'analysis_timestamp': datetime.now().isoformat(),
-                'model_used': 'gemini-2.5-flash'
+                'model_used': 'gemini-2.5-flash',
             }
-            
+
             logger.info("Article analysis completed successfully")
             return analysis
-            
-        except Exception as e:
-            logger.error(f"Failed to analyze article: {str(e)}")
+
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error(f"Failed to analyze article: {exc}")
             return {
                 'article_title': article.get('title', 'Unknown'),
                 'article_url': article.get('url', article.get('uri', 'No URL')),
-                'analysis_text': f"Analysis failed: {str(e)}",
+                'analysis_text': f"Analysis failed: {exc}",
                 'analysis_timestamp': datetime.now().isoformat(),
                 'model_used': 'gemini-2.5-flash',
-                'error': True
+                'error': True,
             }
-    
+
+    def generate_article(self, article: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate a publishable article for the provided news item."""
+        title = article.get('title', 'Untitled Article')
+        summary = article.get('body', article.get('summary', ''))
+        url = article.get('url', article.get('uri', ''))
+
+        prompt = self._create_article_prompt(title, summary, url)
+
+        try:
+            logger.info(f"Generating long-form article: {title[:50]}...")
+            response = self.client.models.generate_content(
+                model="gemini-2.5-flash",
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    thinking_config=types.ThinkingConfig(thinking_budget=0)
+                ),
+            )
+
+            structured_article = self._parse_article_response(
+                response.text,
+                fallback_headline=title,
+                fallback_subhead=article.get('summary', '')
+                or 'Insights on the latest Bitcoin mining developments',
+            )
+
+            structured_article.update(
+                {
+                    'source_title': title,
+                    'source_url': url,
+                    'generated_timestamp': datetime.now().isoformat(),
+                    'model_used': 'gemini-2.5-flash',
+                }
+            )
+
+            logger.info("Article generation completed successfully")
+            return structured_article
+
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error(f"Failed to generate article: {exc}")
+            return {
+                'headline': title,
+                'subhead': 'Failed to generate article',
+                'sections': [
+                    {
+                        'title': 'Generation Error',
+                        'content': f"The article could not be generated due to: {exc}",
+                    }
+                ],
+                'source_title': title,
+                'source_url': url,
+                'generated_timestamp': datetime.now().isoformat(),
+                'model_used': 'gemini-2.5-flash',
+                'error': True,
+            }
+
     def _create_analysis_prompt(self, title: str, body: str, url: str) -> str:
-        """Create a detailed analysis prompt for the article"""
+        """Create a detailed analysis prompt for the article."""
         prompt = f"""
 Analyze the following Bitcoin mining news article and provide a comprehensive analysis:
 
@@ -91,81 +143,130 @@ Analyze the following Bitcoin mining news article and provide a comprehensive an
 Please provide a detailed analysis covering:
 
 1. **Key Points Summary**: Main points and developments mentioned in the article
-
 2. **Bitcoin Mining Impact**: How this news affects the Bitcoin mining industry specifically
-
 3. **Market Implications**: Potential impact on Bitcoin mining companies, hashrate, difficulty, or mining economics
-
 4. **Technical Analysis**: Any technical aspects related to mining hardware, software, or infrastructure
-
 5. **Regulatory/Policy Implications**: Any regulatory or policy implications for Bitcoin mining
-
 6. **Future Outlook**: What this means for the future of Bitcoin mining
-
 7. **Investment Considerations**: Potential implications for Bitcoin mining investments
 
 Format your response in clear, well-structured markdown with appropriate headings and bullet points.
 """
         return prompt
 
+    def _create_article_prompt(self, title: str, body: str, url: str) -> str:
+        """Create prompt that requests a fully publishable article."""
+        trimmed_body = body[:4000]
+        prompt = f"""
+You are a financial journalist focused on Bitcoin mining.
+
+Using the information provided, write a publishable news article that follows this JSON schema:
+
+{{
+  "headline": "Compelling headline",
+  "subhead": "One sentence subhead providing context",
+  "sections": [
+    {{"title": "Section heading", "content": "2-3 paragraphs expanding on the topic"}}
+  ]
+}}
+
+Guidelines:
+- Maintain journalistic neutrality and cite concrete facts from the source material.
+- Include at least three body sections covering background, impact on Bitcoin mining, and market or regulatory implications.
+- Avoid Markdown formatting in the JSON values; provide plain text paragraphs.
+
+Source Article Title: {title}
+Source Article URL: {url}
+Source Article Content:
+"""
+        return prompt + trimmed_body
+
+    def _parse_article_response(
+        self,
+        response_text: str,
+        fallback_headline: str,
+        fallback_subhead: str,
+    ) -> Dict[str, Any]:
+        """Parse Gemini response text into a structured article object."""
+
+        def _normalize_sections(sections: Any) -> List[Dict[str, str]]:
+            normalized: List[Dict[str, str]] = []
+            if isinstance(sections, list):
+                for index, section in enumerate(sections, start=1):
+                    if isinstance(section, dict):
+                        title = section.get('title') or section.get('heading') or f'Section {index}'
+                        content = section.get('content') or section.get('body', '')
+                    else:
+                        title = f'Section {index}'
+                        content = str(section)
+                    normalized.append({'title': title.strip(), 'content': content.strip()})
+            return [item for item in normalized if item['content']]
+
+        try:
+            data = json.loads(response_text)
+            headline = (data.get('headline') or fallback_headline).strip()
+            subhead = (data.get('subhead') or fallback_subhead).strip()
+            sections = _normalize_sections(data.get('sections', []))
+        except (json.JSONDecodeError, AttributeError):
+            logger.debug("Gemini article response was not valid JSON; using fallback structure")
+            headline = fallback_headline
+            subhead = fallback_subhead
+            sections = _normalize_sections([])
+
+        if not sections:
+            sections = [
+                {
+                    'title': 'Key Developments',
+                    'content': response_text.strip(),
+                }
+            ]
+
+        return {
+            'headline': headline,
+            'subhead': subhead,
+            'sections': sections,
+            'raw_text': response_text,
+        }
+
 
 class ReportGenerator:
-    """Generates and saves markdown reports for analyzed articles"""
-    
+    """Generates and saves markdown reports for analyzed articles."""
+
     def __init__(self, reports_dir: str = "files/reports"):
-        """Initialize report generator"""
         self.reports_dir = reports_dir
         self._ensure_reports_directory()
-    
-    def _ensure_reports_directory(self):
-        """Ensure the reports directory exists"""
+
+    def _ensure_reports_directory(self) -> None:
         os.makedirs(self.reports_dir, exist_ok=True)
         logger.info(f"Reports directory ensured: {self.reports_dir}")
-    
+
     def save_analysis_report(self, analysis: Dict[str, Any]) -> Optional[str]:
-        """
-        Save analysis report as markdown file
-        
-        Args:
-            analysis: Analysis results from Gemini
-            
-        Returns:
-            Path to saved report file, or None if failed
-        """
+        """Save analysis report as markdown file."""
         try:
-            # Generate filename based on article title and timestamp
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             title_slug = self._create_filename_slug(analysis['article_title'])
             filename = f"{timestamp}_{title_slug}.md"
             filepath = os.path.join(self.reports_dir, filename)
-            
-            # Generate markdown content
+
             markdown_content = self._generate_markdown_report(analysis)
-            
-            # Save to file
-            with open(filepath, 'w', encoding='utf-8') as f:
-                f.write(markdown_content)
-            
+
+            with open(filepath, 'w', encoding='utf-8') as handle:
+                handle.write(markdown_content)
+
             logger.info(f"Analysis report saved: {filepath}")
             return filepath
-            
-        except Exception as e:
-            logger.error(f"Failed to save analysis report: {str(e)}")
+
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error(f"Failed to save analysis report: {exc}")
             return None
-    
+
     def _create_filename_slug(self, title: str) -> str:
-        """Create a safe filename slug from article title"""
-        import re
-        # Remove special characters and limit length
-        slug = re.sub(r'[^\w\s-]', '', title.lower())
-        slug = re.sub(r'[-\s]+', '_', slug)
-        return slug[:50]  # Limit length
-    
+        return create_filename_slug(title)
+
     def _generate_markdown_report(self, analysis: Dict[str, Any]) -> str:
-        """Generate markdown content for the analysis report"""
         timestamp = analysis.get('analysis_timestamp', datetime.now().isoformat())
         model = analysis.get('model_used', 'Unknown')
-        
+
         markdown = f"""# Bitcoin Mining News Analysis Report
 
 ## Article Information
@@ -185,3 +286,64 @@ class ReportGenerator:
 *This report was automatically generated by the Bitcoin Mining News Bot using AI analysis.*
 """
         return markdown
+
+
+class ArticleContentManager:
+    """Persist structured articles generated by Gemini."""
+
+    def __init__(self, content_dir: str = "files/articles"):
+        self.content_dir = content_dir
+        self._ensure_directory()
+
+    def _ensure_directory(self) -> None:
+        os.makedirs(self.content_dir, exist_ok=True)
+        logger.info(f"Article content directory ensured: {self.content_dir}")
+
+    def save_article(self, article: Dict[str, Any], source_article: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """Save the structured article to disk as markdown."""
+        headline = article.get('headline') or (source_article or {}).get('title') or 'Bitcoin Mining Article'
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        slug = create_filename_slug(headline)
+        filename = f"{timestamp}_{slug}.md"
+        filepath = os.path.join(self.content_dir, filename)
+
+        markdown_content = self._render_article(article, source_article)
+
+        try:
+            with open(filepath, 'w', encoding='utf-8') as handle:
+                handle.write(markdown_content)
+            logger.info(f"Article saved to {filepath}")
+            return filepath
+        except OSError as exc:  # pragma: no cover - file system edge case
+            logger.error(f"Failed to save article content: {exc}")
+            return None
+
+    def _render_article(self, article: Dict[str, Any], source_article: Optional[Dict[str, Any]] = None) -> str:
+        """Render the structured article as markdown content."""
+        headline = article.get('headline', 'Bitcoin Mining Article')
+        subhead = article.get('subhead', '')
+        sections: List[Dict[str, str]] = article.get('sections', [])
+
+        lines: List[str] = [f"# {headline.strip()}", ""]
+
+        if subhead:
+            lines.extend([f"## {subhead.strip()}", ""])
+
+        for section in sections:
+            title = section.get('title', '').strip() or 'Section'
+            content = section.get('content', '').strip()
+            if not content:
+                continue
+            lines.extend([f"### {title}", "", content, ""])
+
+        if source_article:
+            lines.extend([
+                "---",
+                "",
+                "## Source Information",
+                "",
+                f"- Original Title: {source_article.get('title', 'Unknown')}",
+                f"- Source URL: {source_article.get('url', source_article.get('uri', 'Unknown'))}",
+            ])
+
+        return "\n".join(lines).strip() + "\n"

--- a/tests/test_article_generation.py
+++ b/tests/test_article_generation.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+from typing import Dict
+from unittest import mock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+if "tweepy" not in sys.modules:
+    sys.modules["tweepy"] = mock.MagicMock()
+
+if "eventregistry" not in sys.modules:
+    sys.modules["eventregistry"] = mock.MagicMock()
+
+google_module = mock.MagicMock()
+google_genai_module = mock.MagicMock()
+google_types_module = mock.MagicMock()
+google_module.genai = google_genai_module
+google_genai_module.types = google_types_module
+
+sys.modules.setdefault("google", google_module)
+sys.modules.setdefault("google.genai", google_genai_module)
+sys.modules.setdefault("google.genai.types", google_types_module)
+
+from bot import BitcoinMiningNewsBot
+from gemini_client import ArticleContentManager
+
+
+class DummyGeminiClient:
+    def __init__(self, article_response: Dict[str, object]):
+        self.article_response = article_response
+
+    def generate_article(self, article: Dict[str, object]):
+        return self.article_response
+
+
+@pytest.fixture()
+def sample_article() -> Dict[str, str]:
+    return {
+        "title": "Bitcoin miners expand operations amid price surge",
+        "summary": "Operators respond to market signals with new investments.",
+        "body": "Bitcoin miners are expanding operations...",
+        "url": "https://example.com/miners-expand",
+    }
+
+
+@pytest.fixture()
+def generated_article() -> Dict[str, object]:
+    return {
+        "headline": "Bitcoin Miners Accelerate Expansion",
+        "subhead": "Infrastructure upgrades aim to capitalise on higher BTC prices.",
+        "sections": [
+            {"title": "Background", "content": "The mining sector has seen renewed interest."},
+            {"title": "Hashrate Impact", "content": "Hashrate projections point to sustained growth."},
+            {"title": "Regulatory Outlook", "content": "Policy makers remain cautious but open to innovation."},
+        ],
+    }
+
+
+def test_generated_article_saved_with_structure(tmp_path: Path, sample_article: Dict[str, str], generated_article: Dict[str, object]):
+    bot = BitcoinMiningNewsBot(safe_mode=True)
+    bot.article_content_manager = ArticleContentManager(content_dir=str(tmp_path))
+
+    dummy_gemini = DummyGeminiClient(generated_article)
+    bot.api_manager.gemini_client = dummy_gemini
+
+    bot._generate_and_save_article(sample_article)
+
+    files = list(tmp_path.glob("*.md"))
+    assert len(files) == 1, "Expected one generated article file"
+
+    content = files[0].read_text(encoding="utf-8")
+
+    lines = [line for line in content.splitlines() if line.strip()]
+    assert lines[0].startswith("# ")
+    assert any(line.startswith("## ") for line in lines[1:]), "Subhead missing"
+    section_headers = [line for line in lines if line.startswith("### ")]
+    assert len(section_headers) >= 3, "Expected at least three body sections"
+
+    # Ensure original metadata is preserved for traceability
+    assert "Source URL" in content


### PR DESCRIPTION
## Summary
- add a Gemini article generation pipeline that produces structured long-form content alongside analysis reports
- persist generated stories to a dedicated articles directory via the new ArticleContentManager
- cover the workflow with a unit test that mocks Gemini and verifies the Markdown structure

## Testing
- pytest tests/test_article_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0cd199dc8329bcd541fc538b8dac